### PR TITLE
Add function to uncalip all fns

### DIFF
--- a/src/calip/core.clj
+++ b/src/calip/core.clj
@@ -215,6 +215,12 @@
     (when-not *silent*
       (println "remove a wrapper from" f))))
 
+(defn uncalip-all
+  "Looks through all loaded functions (namespace vars) and removes
+   any trace or measure from them. "
+  []
+  (uncalip (wrapped)))
+
 (defn untrace [fs]
   "takes a set of functions (namespace vars) and removes µ/trace from them.
    i.e. (untrace #{#'app/foo #'app/bar})"


### PR DESCRIPTION
In case you register many functions with calip, and want to unregister them all.  For example, if calip is used with defstate.